### PR TITLE
Add StrictConcurrency experimental feature

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,10 +20,17 @@ let package = Package(
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "MapKitSwiftSearch"),
+            name: "MapKitSwiftSearch",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
+        ),
         .testTarget(
             name: "MapKitSwiftSearchTests",
-            dependencies: ["MapKitSwiftSearch"]
+            dependencies: ["MapKitSwiftSearch"],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
         ),
     ]
 )


### PR DESCRIPTION
## Summary
- Enabled the StrictConcurrency experimental feature for all package targets
- Applied to both the main MapKitSwiftSearch library and test targets
- Enhances Swift's concurrency safety checks during compilation

## Test plan
- [x] All existing tests pass with the new strict concurrency checks enabled
- [x] No compilation errors with the stricter concurrency settings

🤖 Generated with [Claude Code](https://claude.ai/code)